### PR TITLE
Avoids false sharing between _top and _bottom

### DIFF
--- a/wsq.hpp
+++ b/wsq.hpp
@@ -4,6 +4,7 @@
 #include <vector>
 #include <optional>
 #include <cassert>
+#include <new>
 
 /**
 @class: WorkStealingQueue
@@ -61,8 +62,14 @@ class WorkStealingQueue {
 
   };
 
-  std::atomic<int64_t> _top;
-  std::atomic<int64_t> _bottom;
+  // avoids false sharing between _top and _bottom
+#ifdef __cpp_lib_hardware_interference_size
+  alignas(std::hardware_destructive_interference_size) std::atomic<int64_t> _top;
+  alignas(std::hardware_destructive_interference_size) std::atomic<int64_t> _bottom;
+#else
+  alignas(64) std::atomic<int64_t> _top;
+  alignas(64) std::atomic<int64_t> _bottom;
+#endif
   std::atomic<Array*> _array;
   std::vector<Array*> _garbage;
 


### PR DESCRIPTION
`_top` and `_bottom` can see their values modified by multiple threads at the same time, leading to false sharing. This can be avoided at the cost of a larger memory footprint by aligning them to the cacheline.

Note that even though `std::hardware_destructive_interference_size` is C++17, [not all compilers implement it](https://en.cppreference.com/w/cpp/compiler_support/17#C.2B.2B17_library_features), so I added a preprocessor check and fallback on the common 64 cacheline size if not present.